### PR TITLE
Fixing age message when new block has less than a minute of life

### DIFF
--- a/index.php
+++ b/index.php
@@ -60,6 +60,9 @@ ini_set('display_errors', 1);
       else if ($age_in_s > 60) {
         $lastblocks[count($lastblocks)-1]->age = gmdate("i", $age_in_s)." mins, ".gmdate("s", $age_in_s)." secs";
       }
+      else {
+        $lastblocks[count($lastblocks)-1]->age = "New block";
+      }
     }
     return $lastblocks;
   }


### PR DESCRIPTION
This PR fix the age message for new blocks having less than a minute of life:

![image](https://user-images.githubusercontent.com/545094/45266271-f8c5ad80-b42e-11e8-91b1-c2feae133077.png)
